### PR TITLE
Tweak

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -62,12 +62,12 @@ author_project_details:
               - project_thumbnail: tetris.jpg
                 project_title: -Py-tris-
                 project_description: Built Tetris using Python
-                project_url: https://github.com/NWMorrison/-Py-tris-
+                project_url: https://nwmorrison.github.io/projects/PyTris/
                 visibility: true
               - project_thumbnail: mctesters.png
                 project_title: McDonald's Automation Testing
                 project_description: Group Project Utilizing Maven Repository
-                project_url: https://github.com/NWMorrison/McTesters
+                project_url: https://nwmorrison.github.io/projects/McTesters/
                 visibility: true
 
 # social links

--- a/_layouts/about-me.html
+++ b/_layouts/about-me.html
@@ -107,7 +107,7 @@ layout: default
           <p class="experience-desc">{{ project.project_description }}</p>
           <p>
             <a class="project-link" href="{{project.project_url}}"
-              >GitHub Repository</a
+              >Overview</a
             >
           </p>
         </div>


### PR DESCRIPTION
Updated "About" Project links to route to the actual project page instead of the git repo. Git repo is found on the project page so redundant.